### PR TITLE
Fix warnings and errors when running tests

### DIFF
--- a/src/common/pos.rs
+++ b/src/common/pos.rs
@@ -106,8 +106,7 @@ impl PartialEq for Pos {
     fn eq(&self, _other: &Self) -> bool { true }
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(not(test), derive(PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SrcRange(Pos, Pos);
 
 impl SrcRange {

--- a/src/compile/compile.rs
+++ b/src/compile/compile.rs
@@ -86,7 +86,7 @@ impl<'s> TryTransformMut<ir::UserTy> for CompileTys<'s> {
     fn try_transform_mut(&mut self, ty: ir::UserTy) -> Result<vm::UserTy, Error> {
         let ir::UserTy {
             name,
-            parents, // TODO: implement type parent behavior
+            parents: _, // TODO: implement type parent behavior
             functions,
             range,
         } = ty;
@@ -173,7 +173,7 @@ impl<'s> TryTransformMut<ir::Fun> for CompileFuns<'s> {
         let ir::Fun {
             symbol,
             params,
-            return_ty, // TODO: implement return type checking
+            return_ty: _, // TODO: implement return type checking
             body,
             inner_types,
             inner_functions,

--- a/src/compile/function.rs
+++ b/src/compile/function.rs
@@ -200,6 +200,7 @@ mod tests {
             name: "a".to_string(),
             symbol: stub_a_sym,
             params: 2,
+            range: Range::Builtin,
             return_ty: ir::TyExpr::None,
         });
 
@@ -215,6 +216,7 @@ mod tests {
             name: "a".to_string(),
             symbol: new_stub_a_sym,
             params: 2,
+            range: Range::Builtin,
             return_ty: ir::TyExpr::None,
         });
         fun_scope.insert(stub_a);
@@ -234,6 +236,7 @@ mod tests {
             name: "a".to_string(),
             symbol: params_stub_a_sym,
             params: 3,
+            range: Range::Builtin,
             return_ty: ir::TyExpr::None,
         });
         fun_scope.insert(stub_a);
@@ -262,6 +265,7 @@ mod tests {
             name: "b".to_string(),
             symbol: stub_a_sym,
             params: 2,
+            range: Range::Builtin,
             return_ty: ir::TyExpr::None,
         });
         let stub_a = fun_scope.replace(stub_b);

--- a/src/compile/value.rs
+++ b/src/compile/value.rs
@@ -316,8 +316,6 @@ impl Default for VarScope {
 
 #[cfg(test)]
 mod tests {
-    use crate::ir;
-    use crate::compile::{FunStub, self};
     use crate::vm::*;
     use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ fn exec(mut args: Args) -> Result<(), common::ProcessError> {
     args.next().expect("exec() must be called with at least 2 args");
     let path = args.next()
         .expect("exec() must be called with at least 2 args");
-    let args: Vec<_> = args.collect();
     let mut compile = compile::Compile::new();
     compile.update_from_path(&path)
 }

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -351,14 +351,13 @@ impl<'c> Iterator for Lexer<'c> {
     }
 }
 
-/*
 #[cfg(test)]
 mod test {
     use super::*;
 
     /// Creates a new lexer with the given input string with a source name of "testing".
     macro_rules! test_lexer {
-        ($input:expr) => {{ Lexer::new($input.chars(), "testing") }};
+        ($input:expr) => {{ Lexer::new("testing", $input) }};
     }
 
     /// Gets the first token from the given string.
@@ -483,4 +482,3 @@ mod test {
         first_token!("\"unclosed string");
     }
 }
-*/

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -574,23 +574,28 @@ impl<'c> Parser<'c> {
     }
 }
 
-/*
 #[cfg(test)]
 mod test {
-    use syntax::*;
-    use syntax::token::*;
-    use syntax::tree::*;
+    use crate::syntax::*;
+    use crate::syntax::token::*;
+    use crate::syntax::tree::*;
+    use crate::common::pos::*;
+    use crate::common::lang::*;
 
     macro_rules! test_parser {
         ($input:expr) => {{
-            let mut parser = Parser::new($input.chars(), "test");
+            let mut parser = Parser::new("test", $input);
             parser.init().unwrap();
             parser
         }};
     }
 
     macro_rules! token {
-        ($($token:tt)+) => { RangedToken::new(Range::new(Pos::default(), Pos::default()), $($token)+) }
+        ($($token:tt)+) => {
+            RangedToken::new(
+                Range::Src(SrcRange::new(Pos::default(),Pos::default())),
+                $($token)+)
+            }
     }
 
     #[test]
@@ -599,11 +604,12 @@ mod test {
         let expr = parser.next_expr().unwrap();
         assert_eq!(expr,
                    Expr::Binary(
-                       Box::new(Expr::Atom(token!(Token::IntLit("1".to_string(), 10)))),
+                       Box::new(Expr::Atom(
+                           token!(Token::IntLit("1".to_string(), 10)))),
                        Op::Plus,
-                       Box::new(Expr::Atom(token!(Token::IntLit("2".to_string(), 10))))
-                       )
-                  );
+                       Box::new(Expr::Atom(
+                           token!(Token::IntLit("2".to_string(), 10))))
+                   ));
     }
 
     #[test]
@@ -616,4 +622,4 @@ mod test {
         parser.match_token(Token::RParen).unwrap();
     }
 }
-*/
+


### PR DESCRIPTION
Tests were failing for two reasons:
- PartialEq was not implemented for SrcRange
- A Range field was added to FunStub, but the tests didn't include it

The rest of the changes were to clean up warnings from the build