### PR TITLE
Use only semicolons to delimit lines

### DIFF
--- a/examples/blocks.npl
+++ b/examples/blocks.npl
@@ -1,52 +1,53 @@
 fun prompt-line($prompt = "> ", $empty-ok = false): Str {
     loop {
-        println($prompt) # TODO: rename to print, once that's implemented
+        # TODO: rename to print, once that's implemented
+        println($prompt);
         $user-line = readln();
         if $user-line || $empty-ok {
-            return $user-line
+            return $user-line;
         }
     }
 }
 
 fun prompt-yes-no($prompt, $default = false): Bool {
     if $default == "y" {
-        $prompt ~= " [Y/n] "
+        $prompt ~= " [Y/n] ";
     } else if $default == false {
-        $prompt ~= " [y/n] "
+        $prompt ~= " [y/n] ";
     } else {
-        $prompt ~= " [y/N] "
+        $prompt ~= " [y/N] ";
     }
 
     loop {
-        $user-line = prompt-line($prompt, false)[0]
+        $user-line = prompt-line($prompt, false)[0];
         if $user-line ~~ "y" {
-            return true
+            return true;
         } else if $user-line ~~ "n" {
-            return false
+            return false;
         } else if $default != false {
-            return $default == "y"
+            return $default == "y";
         }
     }
 }
 
-$continue = true
+$continue = true;
 
 loop {
-    $user-line = prompt-line("Collatz sequence of which number?")
+    $user-line = prompt-line("Collatz sequence of which number?");
     if !$user-number ~~ int {
-        println("That doesn't look like a number.")
-        continue
+        println("That doesn't look like a number.");
+        continue;
     }
 
     while $user-number > 1 {
         if $user-number %% 2 {
-            $user-number /= 2
+            $user-number /= 2;
         } else {
-            $user-number += 1
-            $user-number *= 3
+            $user-number += 1;
+            $user-number *= 3;
         }
-        println($user-number)
+        println($user-number);
     }
 
-    $continue = prompt-yes-no("Another one?")
+    $continue = prompt-yes-no("Another one?");
 }

--- a/examples/exprs.npl
+++ b/examples/exprs.npl
@@ -1,19 +1,19 @@
-$some-string = "Hell world"
+$some-string = "Hell world";
 
-println($some-string)
+println($some-string);
 
 #$yo-mama = [
 #    "when she goes camping, the bears hide *their* food!",
 #    "when she sits around the house, she sits *around* the house!",
 #    "she can eat 10 pizzas!",
-#]
+#];
 
-#println("Yo mama so fat, " ~ choose($yo-mama))
+#println("Yo mama so fat, " ~ choose($yo-mama));
 
 # This language is weakly and dynamically typed. These are all valid:
 
-$sum = 1 + 3.5
-$sum = 1 + "5.0"
-$sum = "1" + 3.5
+$sum = 1 + 3.5;
+$sum = 1 + "5.0";
+$sum = "1" + 3.5;
 # Hold on to your butts - adding strings like they were ints is allowed, too.
-$sum = "3.5" + "1"
+$sum = "3.5" + "1";

--- a/src/syntax/error.rs
+++ b/src/syntax/error.rs
@@ -10,8 +10,8 @@ pub enum ErrorKind {
     #[fail(display = "unexpected {}", _0)]
     Unexpected(String),
 
-    #[fail(display = "expected {}; got {}", _0, _1)]
-    ExpectedGot(String, String),
+    #[fail(display = "expected {}; got {} at {}", _0, _1, _2)]
+    ExpectedGot(String, String, Pos),
 
     #[fail(display = "reached {} while insode of string literal", _0)]
     EarlyStringEnd(String),

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -89,7 +89,6 @@ impl<'c> Lexer<'c> {
             '[' => Some(Ok(Token::LBracket)),
             ']' => Some(Ok(Token::RBracket)),
             ';' => Some(Ok(Token::LineEnd)),
-            '\n' => Some(Ok(Token::NewLine)),
             ',' => Some(Ok(Token::Comma)),
             ':' => Some(Ok(Token::Colon)),
             '0' ... '9' => Some(self.next_numeric_token()),
@@ -316,7 +315,9 @@ impl<'c> Lexer<'c> {
     /// # Returns
     /// The previous "current character" that has just been replaced.
     fn next_char(&mut self) -> Option<char> {
-        let old = mem::replace(&mut self.curr, mem::replace(&mut self.next, self.input.next()));
+        let old = mem::replace(&mut self.curr,
+                               mem::replace(&mut self.next,
+                                            self.input.next()));
         if let Some(c) = old {
             self.pos.adv();
             if c == '\n' {
@@ -331,7 +332,7 @@ impl<'c> Lexer<'c> {
     }
     
     fn err_expected_got(&self, expected: impl ToString, got: impl ToString) -> Error {
-        self.err(ErrorKind::ExpectedGot(expected.to_string(), got.to_string()))
+        self.err(ErrorKind::ExpectedGot(expected.to_string(), got.to_string(), self.pos()))
     }
 
     fn err(&self, kind: ErrorKind) -> Error {

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -193,7 +193,7 @@ impl<'c> Parser<'c> {
             // EOF
             Ok(())
         } else {
-            Err(self.err_expected_got("end-of-line (newline or `;`) or EOF", self.curr.as_ref()))
+            Err(self.err_expected_got("end-of-line (`;`) or EOF", self.curr.as_ref()))
         }
     }
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -169,14 +169,15 @@ impl<'c> Parser<'c> {
             _ => return Err(self.err_expected_got("statement", self.curr.as_ref())),
         };
         let is_newline_needed = match stmt {
-            Stmt::Fun(_) => true,
-            Stmt::While(_) => true,
+            Stmt::Fun(_) => false,
+            Stmt::While(_) => false,
             Stmt::If {
                 if_block: _,
                 elseif_blocks: _,
                 else_block: _,
-            } => true,
-            _ => false,
+            } => false,
+            Stmt::Loop(_) => false,
+            _ => true,
         };
 
         if is_newline_needed {

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -107,7 +107,6 @@ pub enum Token {
     // Control tokens
     //
     LineEnd,
-    NewLine,
 }
 
 impl Token {
@@ -186,7 +185,6 @@ impl Token {
             LBracket => "[".to_string(),
             RBracket => "]".to_string(),
             LineEnd => ";".to_string(),
-            NewLine => "\n".to_string(),
         }
     }
 }
@@ -222,7 +220,7 @@ impl Display for Token {
             RBrace => write!(fmt, "right brace"),
             LBracket => write!(fmt, "left bracket"),
             RBracket => write!(fmt, "right bracket"),
-            NewLine | LineEnd => write!(fmt, "end-of-line"),
+            LineEnd => write!(fmt, "end-of-line"),
         }
     }
 }

--- a/src/syntax/tree.rs
+++ b/src/syntax/tree.rs
@@ -74,7 +74,8 @@ pub enum Stmt {
 
 impl Ast for Stmt {
     fn token_is_lookahead(token: &Token) -> bool {
-        Expr::token_is_lookahead(token) || token_is_lookahead!(token, Token::FunKw, Token::ReturnKw, Token::IfKw)
+        Expr::token_is_lookahead(token) ||
+            token_is_lookahead!(token, Token::FunKw, Token::ReturnKw, Token::IfKw)
     }
 
     fn name() -> &'static str { "statement" }


### PR DESCRIPTION
Removes `newline` as a valid token, so that it will just be treated like whitespace.
- Added semicolons to example files
- Added position indicator to `err_expected_got` (useful for debugging - seemed worth keeping)
- Wrapped some 80+ character lines (a personal hangup)